### PR TITLE
Rich Display Enhancements

### DIFF
--- a/src/lib/util/ReactionHandler.js
+++ b/src/lib/util/ReactionHandler.js
@@ -111,9 +111,14 @@ class ReactionHandler extends ReactionCollector {
 		else return this.stop();
 
 		this.on('collect', (reaction, user) => {
-			reaction.users.remove(user);
+			if (message.guild && message.guild.me.permissions.has('MANAGE_MESSAGES')) reaction.users.remove(user);
 			this[this.methodMap.get(reaction.emoji.id || reaction.emoji.name)](user);
 		});
+		if (!message.guild || !message.guild.me.permissions.has('MANAGE_MESSAGES')) {
+			this.on('remove', (reaction, user) => {
+				this[this.methodMap.get(reaction.emoji.id || reaction.emoji.name)](user);
+			});
+		}
 		this.on('end', () => {
 			if (this.reactionsDone && !this.message.deleted) this.message.reactions.removeAll();
 		});


### PR DESCRIPTION
### Description of the PR
With this PR, RichDisplays will work perfectly in DM, and without Manage Messages even in a guild. If you do have Manage Messages in a guild the functionality remains the same. Most of the errors that spam consoles are also fixed now with this PR.

The problems that caused an enormous spam of errors in consoles came from missing Manage Message perm in a guild or in a DM. Either way this limited the functionality of RichDisplays a lot. The reason this was happening is because the current way **always** requires removing the users reaction and doesn't check if it has permissions to remove. This would lead to a massive amount of errors.

Also the main issue is that extending RichDisplays to solve this was near impossible or at the minimum very frustrating. It can not be solved by using an extendable on ReactionCollector because the problems were in the `listeners`. Even by making a new class that extended it we would still have the other listeners and then need to first somehow clean them and then recreate these. The simplest solution in my opinion is just adding a simple if check to know how to handle it. If the bot has manage message perms do it like normal, if it does not then dont remove reactions automatically but add a `remove` listener for that collector so users don't need to click twice.

### Changes Proposed in this Pull Request (List new items in CHANGELOG.MD)

- Add check to prevent error spam
- Add remove listener to allow RD to work on 1 tap and not 2 reactions when missing perm.

### Semver Classification

- [ ] This PR only includes documentation or non-code changes.
- [x] This PR fixes a bug and does not change the (intended) framework interface.
- [ ] This PR adds methods or properties to the framework interface.
- [ ] This PR removes or renames methods or properties in the framework interface.
